### PR TITLE
Async action filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore all logfiles and tempfiles.
 /**/bin
+/**/obj
 /**/.DS_Store
 /**/*.db
 /**/project.lock.json

--- a/src/Toucan/ToucanAuthorizationFilter.cs
+++ b/src/Toucan/ToucanAuthorizationFilter.cs
@@ -71,8 +71,8 @@ namespace Toucan
                 {
                     context.Result = new ChallengeResult();
                 }
-                await next();
-            }   
+            }
+            await next();   
         }
     }
 }


### PR DESCRIPTION
This changes the action filter to be asynchronous. This prevents blocking and avoids a deadlock that can occur in ASP.NET when running a task synchronously.

This may be worth testing before accepting the merge. One thing that is different about async action filters is you are responsible as an implementor for calling the next action filter with `await next()`. I believe I caught all of the cases where the action filter pipeline needs to be continued.
